### PR TITLE
HTTP/HTTPS Proxy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ set address lookup options
         `countryMatch`: match results in this country only. (ISO 3166-1 country code)
         `key`: optional google api key (if used will submit requests over https)
         `language`: optional locale to translate the results into, 'DE' for German, etc.
+        `proxy`: optional proxy address to pass the request through (`http://<proxy_address>:<proxy_port>`)
+
+> **`proxy` note**: when used without a `key` (request via http), the [`url`](https://nodejs.org/docs/latest/api/url.html) object submitted with the request adds the value provided to the `url.proxy` property.
+>
+> however, when used with a `key` (request via https), the `value` is used to create a [`https-proxy-agent`](https://www.npmjs.com/package/https-proxy-agent) and then added to the `url.agent` property to properly implement the [CONNECT HTTP method](https://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_Tunneling).
+>
+> this is to overcome cases where requests made without a supplied agent are [transformed](https://tools.ietf.org/html/rfc7230#section-5.7.2) to scramble the request as a security measure, or in [configurations](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4.2-option%20http-use-proxy-header) that only accept headers specified by [RFC7230](https://tools.ietf.org/html/rfc7230) (using the CONNECT method). note that using this method ensures the tunneling to work whether these proxy/firewall features are present or not.
 
 addressValidator.Address class
 ------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "es6-promisify": "5.0.0"
       }
     },
     "asn1": {
@@ -37,7 +37,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "requires": {
-        "hoek": "0.9.x"
+        "hoek": "0.9.1"
       },
       "dependencies": {
         "hoek": {
@@ -71,7 +71,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "requires": {
-        "boom": "0.4.x"
+        "boom": "0.4.2"
       }
     },
     "ctype": {
@@ -102,7 +102,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.0.3"
       }
     },
     "forever-agent": {
@@ -115,9 +115,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
       "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
       "requires": {
-        "async": "~0.2.7",
-        "combined-stream": "~0.0.4",
-        "mime": "~1.2.2"
+        "async": "0.2.10",
+        "combined-stream": "0.0.7",
+        "mime": "1.2.11"
       }
     },
     "hawk": {
@@ -125,10 +125,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
       "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
       "requires": {
-        "boom": "0.4.x",
-        "cryptiles": "0.2.x",
-        "hoek": "0.8.x",
-        "sntp": "0.2.x"
+        "boom": "0.4.2",
+        "cryptiles": "0.2.2",
+        "hoek": "0.8.5",
+        "sntp": "0.2.4"
       }
     },
     "hoek": {
@@ -151,8 +151,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
+        "agent-base": "4.1.0",
+        "debug": "3.1.0"
       }
     },
     "json-stringify-safe": {
@@ -190,18 +190,18 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.21.0.tgz",
       "integrity": "sha1-VyirnEXlqHyZ2szVMCmLZnOoaNc=",
       "requires": {
-        "aws-sign": "~0.3.0",
-        "cookie-jar": "~0.3.0",
-        "forever-agent": "~0.5.0",
+        "aws-sign": "0.3.0",
+        "cookie-jar": "0.3.0",
+        "forever-agent": "0.5.2",
         "form-data": "0.0.8",
-        "hawk": "~0.13.0",
-        "http-signature": "~0.9.11",
-        "json-stringify-safe": "~4.0.0",
-        "mime": "~1.2.9",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.3.0",
-        "qs": "~0.6.0",
-        "tunnel-agent": "~0.3.0"
+        "hawk": "0.13.1",
+        "http-signature": "0.9.11",
+        "json-stringify-safe": "4.0.0",
+        "mime": "1.2.11",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.3.0",
+        "qs": "0.6.6",
+        "tunnel-agent": "0.3.0"
       }
     },
     "sntp": {
@@ -209,7 +209,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "requires": {
-        "hoek": "0.9.x"
+        "hoek": "0.9.1"
       },
       "dependencies": {
         "hoek": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,11 +185,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
       "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
     "request": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.21.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "asn1": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
@@ -29,7 +37,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       },
       "dependencies": {
         "hoek": {
@@ -63,7 +71,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "requires": {
-        "boom": "0.4.2"
+        "boom": "0.4.x"
       }
     },
     "ctype": {
@@ -71,10 +79,31 @@
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
       "integrity": "sha1-/oCR1Gijc6Cwyf+Lv7NCXACXOh0="
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "delayed-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
       "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "forever-agent": {
       "version": "0.5.2",
@@ -86,9 +115,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
       "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
       "requires": {
-        "async": "0.2.10",
-        "combined-stream": "0.0.7",
-        "mime": "1.2.11"
+        "async": "~0.2.7",
+        "combined-stream": "~0.0.4",
+        "mime": "~1.2.2"
       }
     },
     "hawk": {
@@ -96,10 +125,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
       "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
       "requires": {
-        "boom": "0.4.2",
-        "cryptiles": "0.2.2",
-        "hoek": "0.8.5",
-        "sntp": "0.2.4"
+        "boom": "0.4.x",
+        "cryptiles": "0.2.x",
+        "hoek": "0.8.x",
+        "sntp": "0.2.x"
       }
     },
     "hoek": {
@@ -117,6 +146,15 @@
         "ctype": "0.5.2"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
+    },
     "json-stringify-safe": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-4.0.0.tgz",
@@ -126,6 +164,11 @@
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
       "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node-uuid": {
       "version": "1.4.8",
@@ -142,23 +185,28 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
       "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "request": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.21.0.tgz",
       "integrity": "sha1-VyirnEXlqHyZ2szVMCmLZnOoaNc=",
       "requires": {
-        "aws-sign": "0.3.0",
-        "cookie-jar": "0.3.0",
-        "forever-agent": "0.5.2",
+        "aws-sign": "~0.3.0",
+        "cookie-jar": "~0.3.0",
+        "forever-agent": "~0.5.0",
         "form-data": "0.0.8",
-        "hawk": "0.13.1",
-        "http-signature": "0.9.11",
-        "json-stringify-safe": "4.0.0",
-        "mime": "1.2.11",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.3.0",
-        "qs": "0.6.6",
-        "tunnel-agent": "0.3.0"
+        "hawk": "~0.13.0",
+        "http-signature": "~0.9.11",
+        "json-stringify-safe": "~4.0.0",
+        "mime": "~1.2.9",
+        "node-uuid": "~1.4.0",
+        "oauth-sign": "~0.3.0",
+        "qs": "~0.6.0",
+        "tunnel-agent": "~0.3.0"
       }
     },
     "sntp": {
@@ -166,7 +214,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       },
       "dependencies": {
         "hoek": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-script": "~1.9.3"
   },
   "dependencies": {
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "2.2.1",
     "request": "~2.21.0",
     "underscore": "~1.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "https-proxy-agent": "^2.2.1",
-    "querystring": "^0.2.0",
     "request": "~2.21.0",
     "underscore": "~1.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "coffee-script": "~1.9.3"
   },
   "dependencies": {
-    "underscore": "~1.4.4",
-    "request": "~2.21.0"
+    "https-proxy-agent": "^2.2.1",
+    "querystring": "^0.2.0",
+    "request": "~2.21.0",
+    "underscore": "~1.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-script": "~1.9.3"
   },
   "dependencies": {
-    "https-proxy-agent": "2.2.1",
+    "https-proxy-agent": "~2.2.1",
     "request": "~2.21.0",
     "underscore": "~1.4.4"
   }

--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -1,8 +1,6 @@
 _ = require('underscore')
-url = require('url')
 request = require('request')
-querystring = require('querystring')
-HttpsProxyAgent = require( 'https-proxy-agent' )
+HttpsProxyAgent = require('https-proxy-agent')
 
 options =
   countryBias: "us" #more likely to find addresses in this country. Think of this as you where you are searching "from" to find results around you. (use ISO 3166-1 country code)
@@ -222,17 +220,16 @@ exports.validate = (inputAddr, addressType=defaultMatchType, cb) ->
     qs.key = options.key
     protocol = 'https'
 
-  endpoint = "#{protocol}://maps.googleapis.com/maps/api/geocode/json?#{querystring.stringify(qs)}";
-
-  opts = url.parse(endpoint);
-  opts.url = endpoint;
-  opts.method = 'GET';
-  opts.json = true;
+  opts =
+    json: true,
+    url: "#{protocol}://maps.googleapis.com/maps/api/geocode/json"
+    method: 'GET'
+    qs: qs
 
   if options.proxy
-    if options.key
-      opts.agent = new HttpsProxyAgent( options.proxy );
-    else
+    ### if options.key
+      opts.agent = new HttpsProxyAgent(options.proxy);
+    else ###
       opts.proxy = options.proxy
 
   request(opts, (err, response, body) ->

--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -227,9 +227,9 @@ exports.validate = (inputAddr, addressType=defaultMatchType, cb) ->
     qs: qs
 
   if options.proxy
-    ### if options.key
+    if options.key
       opts.agent = new HttpsProxyAgent(options.proxy);
-    else ###
+    else
       opts.proxy = options.proxy
 
   request(opts, (err, response, body) ->


### PR DESCRIPTION
Added optional proxy support via supplying the proxy address to an additional option to be set with `setOptions`. If the validator is used without a key (*http*) it simply adds the address to the `opts` object supplied to `request` as a `proxy` property . Otherwise, it supplies it via the added `https-proxy-agent` so that it properly maintains the request parameters across various proxy setups.

> In my case, when an `https` request was made through the proxy without a supplied agent, it messed up the request by cloning the `headers` over the `path` property; resulting in the error: `TypeError: Request path contains unescaped characters`.

This also adds two dependencies:
  `https-proxy-agent`, `querystring`

... and builds the `opts` variable supplied to `Request` via the core Node module `url` from the full uri (`protocol`, `url`, `qs`) and then adds the components you've composed the original `opts` from after the fact.